### PR TITLE
show all columns in a parquet file

### DIFF
--- a/parq/main.py
+++ b/parq/main.py
@@ -1,8 +1,9 @@
 from __future__ import print_function
 
-import sys
 import argparse
+import sys
 
+import pandas as pd
 import pyarrow.parquet as pq
 
 
@@ -34,6 +35,8 @@ def main(cmd_args=sys.argv, skip=False):
     """
     if not skip:
         cmd_args = init_args()
+
+    pd.set_option('display.max_columns', None)
 
     pq_table = pq.read_table(cmd_args.file)
     if cmd_args.head:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import sys
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 msg = "Command line (CLI) tool to inspect Apache Parquet files on the go"
 
@@ -34,7 +35,7 @@ setup(
     packages=find_packages(),
     platforms='any',
     install_requires=[
-        'pandas==0.22.0',
+        'pandas>=0.22.0',
         get_pyarrow_version()
     ],
     entry_points={


### PR DESCRIPTION
With the current version, when there are more columns that can fit the screen, pandas will omit some columns.

This PR adds a flag to display all columns on the screen.

Also I changed the strict versioning requirement for pandas.