### PR TITLE
Avoid type casting errors with datetimes & dates

### DIFF
--- a/parq/main.py
+++ b/parq/main.py
@@ -17,8 +17,13 @@ def get_schema(parquet_file):
     return r.schema
 
 
+def pdtbl(pq_table):
+    data = pq_table.to_pandas(date_as_object=True, timestamp_as_object=True)
+    return data
+
+
 def get_data(pq_table, n, head=True):
-    data = pq_table.to_pandas()
+    data = pdtbl(pq_table)
     if head:
         rows = data.head(n)
     else:
@@ -44,7 +49,7 @@ def main(cmd_args=sys.argv, skip=False):
     elif cmd_args.tail:
         print(get_data(pq_table, cmd_args.tail, head=False))
     elif cmd_args.count:
-        print(len(pq_table.to_pandas().index))
+        print(len(pdtbl(pq_table).index))
     elif cmd_args.schema:
         print("\n # Schema \n", get_schema(cmd_args.file))
     else:


### PR DESCRIPTION
- This turns on two flags for the pandas table conversion to treat
  datetime/dates as objects which helps to avoid errors like:

  pyarrow.lib.ArrowInvalid: Casting from timestamp[us] to timestamp[ns] would result in out of bounds timestamp: -29941464600000000

  This is very useful for data derived from sql where the python
  datetime/postgresql types only goes to microseconds or is far in the
  future and causes issues with the pandas format.